### PR TITLE
Fix getc/putc signature in documentation

### DIFF
--- a/doc/source/about.rst
+++ b/doc/source/about.rst
@@ -8,7 +8,7 @@ This package ports the XMODEM, YMODEM and ZMODEM protocols to Python. We try to
 implement the protocols as minimalistic as possible without breaking the
 protocol specifications.
 
-The interface to most modem classes are pretty similair. Keep in mind though,
+The interface to most modem classes are pretty similar. Keep in mind though,
 that the XMODEM protocol can send one file (stream) at a time, whereas the
 YMODEM and ZMODEM protocols can send multiple.
 
@@ -24,11 +24,11 @@ An example using ``STDIN``/``STDOUT`` may read::
 
     >>> import select
     >>> import sys
-    >>> def getc(size, timeout=5):
+    >>> def getc(size, timeout=5, debug=False):
     ...     r, w, e = select.select([sys.stdin.fileno()], [], [], timeout)
     ...     if r: return sys.stdin.read(size)
     ...
-    >>> def putc(data, timeout):
+    >>> def putc(data, timeout, debug=False):
     ...     r, w, e = select.select([], [sys.stdout.fileno()], [], timeout)
     ...     if w: return sys.stdout.write(data)
     ...

--- a/modem/protocol/xmodem.py
+++ b/modem/protocol/xmodem.py
@@ -10,10 +10,10 @@ class XMODEM(Modem):
     XMODEM protocol implementation, expects an object to read from and an
     object to write to.
 
-    >>> def getc(size, timeout=1):
+    >>> def getc(size, timeout=1, debug=False):
     ...     return data or None
     ...
-    >>> def putc(data, timeout=1):
+    >>> def putc(data, timeout=1, debug=False):
     ...     return size or None
     ...
     >>> modem = XMODEM(getc, putc)
@@ -38,7 +38,7 @@ class XMODEM(Modem):
             >>> print modem.send(stream)
             True
 
-        Returns ``True`` upon succesful transmission or ``False`` in case of
+        Returns ``True`` upon successful transmission or ``False`` in case of
         failure.
         '''
 

--- a/modem/protocol/xmodem1k.py
+++ b/modem/protocol/xmodem1k.py
@@ -22,7 +22,7 @@ class XMODEM1K(XMODEM):
             >>> print modem.send(stream)
             True
 
-        Returns ``True`` upon succesful transmission or ``False`` in case of
+        Returns ``True`` upon successful transmission or ``False`` in case of
         failure.
         '''
 

--- a/modem/protocol/xmodemcrc.py
+++ b/modem/protocol/xmodemcrc.py
@@ -23,7 +23,7 @@ class XMODEMCRC(XMODEM):
             >>> print modem.send(stream)
             True
 
-        Returns ``True`` upon succesful transmission or ``False`` in case of
+        Returns ``True`` upon successful transmission or ``False`` in case of
         failure.
         '''
 

--- a/modem/protocol/ymodem.py
+++ b/modem/protocol/ymodem.py
@@ -22,7 +22,7 @@ class YMODEM(XMODEM):
             >>> print modem.send('*.txt')
             True
 
-        Returns ``True`` upon succesful transmission or ``False`` in case of
+        Returns ``True`` upon successful transmission or ``False`` in case of
         failure.
         '''
 


### PR DESCRIPTION
The `_send_packet` function was changed in commit 2e2e46de872 to call `getc` and `putc` with the `debug` argument.

Also some typos were fixed.