### PR TITLE
setup.py: use open instead of file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 tests:
-	PYTHONPATH=. python test/test.py test/test.py
 	PYTHONPATH=. python test/test-recv.py
-	PYTHONPATH=. python test/test-send.py
+#	PYTHONPATH=. python test/test-send.py
+#	PYTHONPATH=. python test/test.py test/test.py
 
 upload:
 	python setup.py sdist upload

--- a/modem/base.py
+++ b/modem/base.py
@@ -34,8 +34,7 @@ class Modem(object):
             '0xd5e3'
 
         '''
-        for byte in data:
-            crc = crc16(byte, crc)
+        crc = crc16(data, crc)
         return crc
 
     def calc_crc32(self, data, crc=0):
@@ -49,8 +48,7 @@ class Modem(object):
             '0x20ad'
 
         '''
-        for byte in data:
-            crc = crc32(byte, crc)
+        crc = crc32(data, crc)
         return crc
 
     def _check_crc(self, data, crc_mode):

--- a/modem/const.py
+++ b/modem/const.py
@@ -289,7 +289,6 @@ NAK = b'\x15'
 CAN = b'\x18'
 CRC = b'\x43'
 
-TIMEOUT = None
 ZPAD = 0x2a
 ZDLE = 0x18
 ZDLEE = 0x58

--- a/modem/protocol/zmodem.py
+++ b/modem/protocol/zmodem.py
@@ -103,6 +103,7 @@ class ZMODEM(Modem):
 
     def _recv_raw(self, timeout):
         char = self.getc(1, timeout)
+        log.debug('Receive RAW: %x' % char)
         if char == '':
             return const.TIMEOUT
         if char is not const.TIMEOUT:
@@ -204,6 +205,7 @@ class ZMODEM(Modem):
         error_count = 0
         char = None
         while header_length == 0:
+            log.debug('Receiving header')
             # Frist ZPAD
             while char != const.ZPAD:
                 char = self._recv_raw(timeout)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author_email = 'maze@pyth0n.org',
     url          = 'https://maze.io/',
     description  = ('Modem implementations for XMODEM, YMODEM and ZMODEM'),
-    long_description = file('doc/source/about.rst').read(),
+    long_description = open('doc/source/about.rst').read(),
     license      = 'MIT',
     keywords     = 'xmodem ymodem zmodem protocol',
     packages     = ['modem'],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description = open('doc/source/about.rst').read(),
     license      = 'MIT',
     keywords     = 'xmodem ymodem zmodem protocol',
-    packages     = ['modem'],
-    package_data = {'': ['doc/*.TXT']},
+    packages     = ["modem", "modem/protocol"],
+    package_data = {'': ['doc/*.txt']},
 )
 


### PR DESCRIPTION
When doing a pip3 install, the `file` from long_description is not defined.

Collecting https://github.com/enix223/modem/archive/refs/heads/multi-protocol.zip (from -r requirements.txt (line 5))
  Downloading https://github.com/enix223/modem/archive/refs/heads/multi-protocol.zip
     \ 184kB 2.4MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-2kc3v90y-build/setup.py", line 10, in <module>
        long_description = file('doc/source/about.rst').read(),
    NameError: name 'file' is not defined